### PR TITLE
CA-132 - fixes log implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ No provider.
 | instance\_count | Number of instances to launch in the ES domain | `number` | `2` | no |
 | instance\_type | Instance type of data nodes in the domain | `string` | `"c5.large.elasticsearch"` | no |
 | kms\_key\_id | The KMS key id to encrypt the Elasticsearch domain with.<br>  If not specified then it defaults to using the aws/es service KMS key | `string` | `null` | no |
-| log\_retention\_in\_days | Specifies the number of days you want to retain log events.<br>  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.<br>  If you select 0, the events in the log group are always retained and never expire. | `number` | `0` | no |
+| log\_group\_name | The name of an existent CloudWatch Log Group that ElasticSearch will publish logs to | `string` | `""` | no |
 | log\_types | A list of log types that will be published to CloudWatch. Valid values are SEARCH\_SLOW\_LOGS, INDEX\_SLOW\_LOGS, ES\_APPLICATION\_LOGS and AUDIT\_LOGS. | `list(string)` | <pre>[<br>  "ES_APPLICATION_LOGS",<br>  "SEARCH_SLOW_LOGS",<br>  "INDEX_SLOW_LOGS"<br>]</pre> | no |
 | node\_to\_node\_encryption\_enabled | Whether to enable node-to-node encryption | `bool` | `true` | no |
 | revoke\_rules\_on\_delete | Whether to revoke rules from the SG upon deletion | `bool` | `true` | no |

--- a/examples/logs/.gitignore
+++ b/examples/logs/.gitignore
@@ -1,0 +1,39 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Ignore terratest configuration
+terratest.tf.json
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Intellij
+.idea/
+*.iml
+
+# Ignore makefile
+ops-makefile

--- a/examples/logs/README.md
+++ b/examples/logs/README.md
@@ -1,0 +1,32 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| name-prefix | A string to prepend to names of resources created by this example | `any` | n/a | yes |
+| create\_new\_service\_role | Whether to create a new IAM service linked role for ES. This only needs to happen once per account. If false, linked\_service\_role is required | `bool` | `false` | no |
+| log\_retention\_in\_days | Specifies the number of days you want to retain log events.<br>  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.<br>  If you select 0, the events in the log group are always retained and never expire. | `number` | `0` | no |
+| log\_types | A list of log types that will be published to CloudWatch. Valid values are SEARCH\_SLOW\_LOGS, INDEX\_SLOW\_LOGS, ES\_APPLICATION\_LOGS and AUDIT\_LOGS. | `list(string)` | <pre>[<br>  "ES_APPLICATION_LOGS",<br>  "SEARCH_SLOW_LOGS",<br>  "INDEX_SLOW_LOGS"<br>]</pre> | no |
+| tags | A map of tags to add to all resources created by this example. | `map(string)` | <pre>{<br>  "Author": "Tamr",<br>  "Environment": "Example"<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| es\_security\_group\_id | ID of the ES domain created |
+| subnet\_id | n/a |
+| tamr\_es\_domain\_endpoint | Endpoint of ES domain created |
+| tamr\_es\_domain\_id | ID of the security group created |
+| vpc\_id | n/a |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/logs/main.tf
+++ b/examples/logs/main.tf
@@ -1,0 +1,54 @@
+resource "aws_vpc" "es_vpc" {
+  cidr_block = "1.2.3.0/24"
+  tags       = var.tags
+}
+
+resource "aws_subnet" "es_subnet" {
+  vpc_id     = aws_vpc.es_vpc.id
+  cidr_block = "1.2.3.0/24"
+  tags       = var.tags
+}
+
+module "sg-ports" {
+  #source = "git::https://github.com/Datatamer/terraform-aws-es.git//modules/es-ports?ref=2.0.0"
+  source = "../../modules/es-ports"
+}
+
+module "aws-sg" {
+  source = "git::git@github.com:Datatamer/terraform-aws-security-groups.git?ref=0.1.0"
+  vpc_id = aws_vpc.es_vpc.id
+  ingress_cidr_blocks = [
+    "1.2.3.0/24"
+  ]
+  egress_cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  ingress_ports  = module.sg-ports.ingress_ports
+  sg_name_prefix = var.name-prefix
+  tags           = var.tags
+}
+
+resource "aws_iam_service_linked_role" "es" {
+  count            = var.create_new_service_role == true ? 1 : 0
+  aws_service_name = "es.amazonaws.com"
+}
+
+module "tamr-es-cluster" {
+  depends_on         = [aws_iam_service_linked_role.es]
+  source             = "../../"
+  vpc_id             = aws_vpc.es_vpc.id
+  domain_name        = format("%s-elasticsearch", var.name-prefix)
+  subnet_ids         = [aws_subnet.es_subnet.id]
+  security_group_ids = module.aws-sg.security_group_ids
+  log_types          = var.log_types
+  log_group_name     = aws_cloudwatch_log_group.es-logs.name
+  tags               = var.tags
+}
+
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key
+resource "aws_cloudwatch_log_group" "es-logs" {
+  name_prefix = format("%s-%s", var.name-prefix, "example-logs")
+
+  retention_in_days = var.log_retention_in_days
+  tags              = var.tags
+}

--- a/examples/logs/outputs.tf
+++ b/examples/logs/outputs.tf
@@ -1,0 +1,22 @@
+output "tamr_es_domain_id" {
+  value       = module.tamr-es-cluster.tamr_es_domain_id
+  description = "ID of the security group created"
+}
+
+output "tamr_es_domain_endpoint" {
+  value       = module.tamr-es-cluster.tamr_es_domain_endpoint
+  description = "Endpoint of ES domain created"
+}
+
+output "es_security_group_id" {
+  value       = module.tamr-es-cluster.es_security_group_ids
+  description = "ID of the ES domain created"
+}
+
+output "vpc_id" {
+  value = aws_vpc.es_vpc.id
+}
+
+output "subnet_id" {
+  value = aws_subnet.es_subnet.id
+}

--- a/examples/logs/variables.tf
+++ b/examples/logs/variables.tf
@@ -1,0 +1,34 @@
+variable "name-prefix" {
+  description = "A string to prepend to names of resources created by this example"
+}
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to add to all resources created by this example."
+  default = {
+    Author      = "Tamr"
+    Environment = "Example"
+  }
+}
+
+variable "create_new_service_role" {
+  default     = false
+  type        = bool
+  description = "Whether to create a new IAM service linked role for ES. This only needs to happen once per account. If false, linked_service_role is required"
+}
+
+
+variable "log_types" {
+  type        = list(string)
+  description = "A list of log types that will be published to CloudWatch. Valid values are SEARCH_SLOW_LOGS, INDEX_SLOW_LOGS, ES_APPLICATION_LOGS and AUDIT_LOGS."
+  default     = ["ES_APPLICATION_LOGS", "SEARCH_SLOW_LOGS", "INDEX_SLOW_LOGS"]
+}
+
+variable "log_retention_in_days" {
+  type        = number
+  description = <<EOF
+  Specifies the number of days you want to retain log events.
+  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
+  If you select 0, the events in the log group are always retained and never expire.
+  EOF
+  default     = 0
+}

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -15,8 +15,6 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | name-prefix | A string to prepend to names of resources created by this example | `any` | n/a | yes |
 | create\_new\_service\_role | Whether to create a new IAM service linked role for ES. This only needs to happen once per account. If false, linked\_service\_role is required | `bool` | `false` | no |
-| log\_retention\_in\_days | Specifies the number of days you want to retain log events.<br>  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.<br>  If you select 0, the events in the log group are always retained and never expire. | `number` | `0` | no |
-| log\_types | A list of log types that will be published to CloudWatch. Valid values are SEARCH\_SLOW\_LOGS, INDEX\_SLOW\_LOGS, ES\_APPLICATION\_LOGS and AUDIT\_LOGS. | `list(string)` | <pre>[<br>  "ES_APPLICATION_LOGS",<br>  "SEARCH_SLOW_LOGS",<br>  "INDEX_SLOW_LOGS"<br>]</pre> | no |
 | tags | A map of tags to add to all resources created by this example. | `map(string)` | <pre>{<br>  "Author": "Tamr",<br>  "Environment": "Example"<br>}</pre> | no |
 
 ## Outputs

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -34,11 +34,11 @@ resource "aws_iam_service_linked_role" "es" {
 }
 
 module "tamr-es-cluster" {
-  depends_on            = [aws_iam_service_linked_role.es]
-  source                = "../../"
-  vpc_id                = aws_vpc.es_vpc.id
-  domain_name           = format("%s-elasticsearch", var.name-prefix)
-  subnet_ids            = [aws_subnet.es_subnet.id]
-  security_group_ids    = module.aws-sg.security_group_ids
-  tags                  = var.tags
+  depends_on         = [aws_iam_service_linked_role.es]
+  source             = "../../"
+  vpc_id             = aws_vpc.es_vpc.id
+  domain_name        = format("%s-elasticsearch", var.name-prefix)
+  subnet_ids         = [aws_subnet.es_subnet.id]
+  security_group_ids = module.aws-sg.security_group_ids
+  tags               = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -35,5 +35,5 @@ module "tamr-es-coudwatch-log-groups" {
   domain_name    = var.domain_name
   tags           = local.effective_tags
   log_types      = var.log_types
-  log_group_name = "" // var.log_group_name
+  log_group_name = var.log_group_name
 }

--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,8 @@ module "tamr-es-cluster" {
 module "tamr-es-coudwatch-log-groups" {
   source = "./modules/cloudwatch-logs"
 
-  domain_name           = var.domain_name
-  tags                  = local.effective_tags
-  log_types             = var.log_types
-  log_retention_in_days = var.log_retention_in_days
+  domain_name    = var.domain_name
+  tags           = local.effective_tags
+  log_types      = var.log_types
+  log_group_name = "" // var.log_group_name
 }

--- a/modules/cloudwatch-logs/README.md
+++ b/modules/cloudwatch-logs/README.md
@@ -15,6 +15,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | domain\_name | The name to give to the ES domain | `string` | `"tamr-es-cluster"` | no |
+| log\_group\_name | The name of an existent CloudWatch Log Group that ElasticSearch will publish logs to | `string` | `""` | no |
 | log\_retention\_in\_days | Specifies the number of days you want to retain log events.<br>  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.<br>  If you select 0, the events in the log group are always retained and never expire. | `number` | `0` | no |
 | log\_types | A list of log types that will be published to CloudWatch. Valid values are SEARCH\_SLOW\_LOGS, INDEX\_SLOW\_LOGS, ES\_APPLICATION\_LOGS and AUDIT\_LOGS. | `list(string)` | <pre>[<br>  "ES_APPLICATION_LOGS",<br>  "SEARCH_SLOW_LOGS",<br>  "INDEX_SLOW_LOGS"<br>]</pre> | no |
 | tags | A map of tags to add to CloudWatch resources. | `map(string)` | `{}` | no |

--- a/modules/cloudwatch-logs/main.tf
+++ b/modules/cloudwatch-logs/main.tf
@@ -12,9 +12,9 @@ data "aws_iam_policy_document" "es-tamr-log-publishing-policy" {
       "logs:PutLogEventsBatch",
     ]
 
-    resources = (one(data.aws_cloudwatch_log_group.es-logs[*].arn) == null ? 
-                [] :
-                [one(data.aws_cloudwatch_log_group.es-logs[*].arn)])
+    resources = (one(data.aws_cloudwatch_log_group.es-logs[*].arn) == null ?
+      [] :
+    [one(data.aws_cloudwatch_log_group.es-logs[*].arn)])
 
     principals {
       identifiers = ["es.amazonaws.com"]

--- a/modules/cloudwatch-logs/main.tf
+++ b/modules/cloudwatch-logs/main.tf
@@ -1,11 +1,7 @@
 #tfsec:ignore:aws-cloudwatch-log-group-customer-key
-resource "aws_cloudwatch_log_group" "es-logs" {
-  for_each = toset(var.log_types)
-
-  name_prefix = format("%s-%s", var.domain_name, each.value)
-
-  retention_in_days = var.log_retention_in_days
-  tags              = var.tags
+data "aws_cloudwatch_log_group" "es-logs" {
+  count = var.log_group_name != "" ? 1 : 0
+  name  = var.log_group_name
 }
 
 data "aws_iam_policy_document" "es-tamr-log-publishing-policy" {
@@ -16,7 +12,9 @@ data "aws_iam_policy_document" "es-tamr-log-publishing-policy" {
       "logs:PutLogEventsBatch",
     ]
 
-    resources = [for i in aws_cloudwatch_log_group.es-logs : "${i.arn}:*"]
+    resources = (one(data.aws_cloudwatch_log_group.es-logs[*].arn) == null ? 
+                [] :
+                [one(data.aws_cloudwatch_log_group.es-logs[*].arn)])
 
     principals {
       identifiers = ["es.amazonaws.com"]
@@ -26,7 +24,7 @@ data "aws_iam_policy_document" "es-tamr-log-publishing-policy" {
 }
 
 resource "aws_cloudwatch_log_resource_policy" "es-tamr-log-publishing-policy" {
-  count           = length(var.log_types) > 0 ? 1 : 0
+  count           = length(var.log_types) > 0 && var.log_group_name != "" ? 1 : 0
   policy_document = data.aws_iam_policy_document.es-tamr-log-publishing-policy.json
   policy_name     = "es-tamr-log-publishing-policy-${random_string.suffix.id}"
 }

--- a/modules/cloudwatch-logs/outputs.tf
+++ b/modules/cloudwatch-logs/outputs.tf
@@ -1,3 +1,6 @@
 output "log_publishing_options" {
-  value = [for key, log_group in aws_cloudwatch_log_group.es-logs : { "log_group_arn" = log_group.arn, "log_type" = key }]
+  value = (var.log_group_name == "" ? [] : 
+            [for type in var.log_types : { "log_group_arn" = one(data.aws_cloudwatch_log_group.es-logs[*].arn),
+                                           "log_type" = type }]
+  )
 }

--- a/modules/cloudwatch-logs/outputs.tf
+++ b/modules/cloudwatch-logs/outputs.tf
@@ -1,6 +1,6 @@
 output "log_publishing_options" {
-  value = (var.log_group_name == "" ? [] : 
-            [for type in var.log_types : { "log_group_arn" = one(data.aws_cloudwatch_log_group.es-logs[*].arn),
-                                           "log_type" = type }]
+  value = (var.log_group_name == "" ? [] :
+    [for type in var.log_types : { "log_group_arn" = one(data.aws_cloudwatch_log_group.es-logs[*].arn),
+    "log_type" = type }]
   )
 }

--- a/modules/cloudwatch-logs/variables.tf
+++ b/modules/cloudwatch-logs/variables.tf
@@ -25,3 +25,9 @@ variable "log_retention_in_days" {
   EOF
   default     = 0
 }
+
+variable "log_group_name" {
+  type        = string
+  description = "The name of an existent CloudWatch Log Group that ElasticSearch will publish logs to"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -178,12 +178,8 @@ variable "log_types" {
   default     = ["ES_APPLICATION_LOGS", "SEARCH_SLOW_LOGS", "INDEX_SLOW_LOGS"]
 }
 
-variable "log_retention_in_days" {
-  type        = number
-  description = <<EOF
-  Specifies the number of days you want to retain log events.
-  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0.
-  If you select 0, the events in the log group are always retained and never expire.
-  EOF
-  default     = 0
+variable "log_group_name" {
+  type        = string
+  description = "The name of an existent CloudWatch Log Group that ElasticSearch will publish logs to"
+  default     = ""
 }


### PR DESCRIPTION
Now it doesn't create a log group, instead expects an existent log group name (var), adds the policy and ES configurations needed.